### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ A Model Context Protocol (MCP) server that connects to [Heurist Mesh](https://gi
 
 Heurist Mesh is an open network of purpose-built AI agents and tools, each specialized in particular web3 domains such as blockchain data analysis, smart contract security, token metrics, and blockchain interaction. We are actively growing the Heurist Mesh ecosystem, continuously integrating more tools to expand its capabilities.
 
+<a href="https://glama.ai/mcp/servers/@heurist-network/heurist-mesh-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@heurist-network/heurist-mesh-mcp-server/badge" alt="Mesh Agent Server MCP server" />
+</a>
+
 ## Features
 - Connects to the Heurist Mesh API 
 - Loads tools for cryptocurrency data and Web3 use cases


### PR DESCRIPTION
This PR adds a badge for the [Mesh Agent MCP Server](https://glama.ai/mcp/servers/@heurist-network/heurist-mesh-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@heurist-network/heurist-mesh-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@heurist-network/heurist-mesh-mcp-server/badge" alt="Mesh Agent Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.