### PR TITLE
Enable dynamic tool definition updates via metadata refresh

### DIFF
--- a/mesh_mcp_server/agents_server.py
+++ b/mesh_mcp_server/agents_server.py
@@ -29,6 +29,7 @@ logger = colorlog.getLogger("mesh-mcp")
 logger.handlers = []
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
+logger.propagate = False
 
 # Suppress noisy MCP library logs (ClosedResourceError is expected in stateless mode)
 logging.getLogger("mcp.server.streamable_http").setLevel(logging.CRITICAL)

--- a/mesh_mcp_server/agents_server.py
+++ b/mesh_mcp_server/agents_server.py
@@ -495,6 +495,10 @@ async def lifespan(app: Starlette):
         f"(interval: {METADATA_MANAGER.refresh_interval}s)"
     )
 
+    CURATED_MCP.streamable_http_app()
+    for agent_mcp in AGENT_MCPS.values():
+        agent_mcp.streamable_http_app()
+
     async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(CURATED_MCP.session_manager.run())
         for agent_mcp in AGENT_MCPS.values():


### PR DESCRIPTION
Implements automatic metadata refresh every 10 minutes with true dynamic 
tool definition updates. Replaces static Mount routing with DynamicMCPMiddleware 
that performs runtime lookup of MCP instances - no server restart required 
when mesh API adds/modifies agent tools.

Changes:
- Add MetadataManager for periodic refresh (10 min interval)
- Add DynamicMCPMiddleware for runtime MCP routing  
- Add POST /mcp/refresh endpoint for manual refresh
- Enhance /mcp/health with refresh status